### PR TITLE
logger: add With() method to persist log labels

### DIFF
--- a/loggers/noop/context.go
+++ b/loggers/noop/context.go
@@ -1,0 +1,81 @@
+package noop
+
+import (
+	"net"
+
+	"github.com/loopholelabs/logging/types"
+)
+
+var _ types.Context = (*Context)(nil)
+
+type Context struct {
+	l *Logger
+}
+
+func (c *Context) Logger() types.SubLogger {
+	return c.l
+}
+
+func (c *Context) Str(key string, val string) types.Context {
+	return c
+}
+
+func (c *Context) Bool(key string, val bool) types.Context {
+	return c
+}
+
+func (c *Context) Int(key string, val int) types.Context {
+	return c
+}
+
+func (c *Context) Int8(key string, val int8) types.Context {
+	return c
+}
+
+func (c *Context) Int16(key string, val int16) types.Context {
+	return c
+}
+
+func (c *Context) Int32(key string, val int32) types.Context {
+	return c
+}
+
+func (c *Context) Int64(key string, val int64) types.Context {
+	return c
+}
+
+func (c *Context) Uint(key string, val uint) types.Context {
+	return c
+}
+
+func (c *Context) Uint8(key string, val uint8) types.Context {
+	return c
+}
+
+func (c *Context) Uint16(key string, val uint16) types.Context {
+	return c
+}
+
+func (c *Context) Uint32(key string, val uint32) types.Context {
+	return c
+}
+
+func (c *Context) Uint64(key string, val uint64) types.Context {
+	return c
+}
+
+func (c *Context) Float32(key string, val float32) types.Context {
+	return c
+}
+
+func (c *Context) Float64(key string, val float64) types.Context {
+	return c
+}
+
+func (c *Context) IPAddr(key string, ipAddr net.IP) types.Context {
+	return c
+}
+
+func (c *Context) MACAddr(key string, macAddr net.HardwareAddr) types.Context {
+	return c
+}

--- a/loggers/noop/noop.go
+++ b/loggers/noop/noop.go
@@ -24,6 +24,10 @@ func (s *Logger) Level() types.Level {
 
 func (s *Logger) SubLogger(string) types.SubLogger { return s }
 
+func (s *Logger) With() types.Context {
+	return &Context{l: s}
+}
+
 func (s *Logger) Fatal() types.Event {
 	return new(Event)
 }

--- a/loggers/slog/context.go
+++ b/loggers/slog/context.go
@@ -1,0 +1,149 @@
+package slog
+
+import (
+	"log/slog"
+	"net"
+
+	"github.com/loopholelabs/logging/types"
+)
+
+var _ types.Context = (*Context)(nil)
+
+type Context struct {
+	l     *Logger
+	attrs []any
+}
+
+func (c *Context) Logger() types.SubLogger {
+	l := New(c.l.source, c.l.level, c.l.output)
+	l.logger = c.l.logger.With(c.attrs...)
+	return l
+}
+
+func (c *Context) Str(key string, val string) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.StringValue(val),
+	})
+	return c
+}
+
+func (c *Context) Bool(key string, val bool) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.BoolValue(val),
+	})
+	return c
+}
+
+func (c *Context) Int(key string, val int) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.IntValue(val),
+	})
+	return c
+}
+
+func (c *Context) Int8(key string, val int8) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.IntValue(int(val)),
+	})
+	return c
+}
+
+func (c *Context) Int16(key string, val int16) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.IntValue(int(val)),
+	})
+	return c
+}
+
+func (c *Context) Int32(key string, val int32) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.IntValue(int(val)),
+	})
+	return c
+}
+
+func (c *Context) Int64(key string, val int64) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.Int64Value(val),
+	})
+	return c
+}
+
+func (c *Context) Uint(key string, val uint) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.Uint64Value(uint64(val)),
+	})
+	return c
+}
+
+func (c *Context) Uint8(key string, val uint8) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.Uint64Value(uint64(val)),
+	})
+	return c
+}
+
+func (c *Context) Uint16(key string, val uint16) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.Uint64Value(uint64(val)),
+	})
+	return c
+}
+
+func (c *Context) Uint32(key string, val uint32) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.Uint64Value(uint64(val)),
+	})
+	return c
+}
+
+func (c *Context) Uint64(key string, val uint64) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.Uint64Value(val),
+	})
+	return c
+}
+
+func (c *Context) Float32(key string, val float32) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.Float64Value(float64(val)),
+	})
+	return c
+}
+
+func (c *Context) Float64(key string, val float64) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.Float64Value(float64(val)),
+	})
+	return c
+}
+
+func (c *Context) IPAddr(key string, ipAddr net.IP) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.StringValue(ipAddr.String()),
+	})
+	return c
+}
+
+func (c *Context) MACAddr(key string, macAddr net.HardwareAddr) types.Context {
+	c.attrs = append(c.attrs, slog.Attr{
+		Key:   key,
+		Value: slog.StringValue(macAddr.String()),
+	})
+	return c
+}

--- a/loggers/slog/slog.go
+++ b/loggers/slog/slog.go
@@ -83,6 +83,10 @@ func (s *Logger) SubLogger(source string) types.SubLogger {
 	return newSlog(fmt.Sprintf("%s:%s", s.source, source), sloglevel, s.output)
 }
 
+func (s *Logger) With() types.Context {
+	return &Context{l: s}
+}
+
 func (s *Logger) Fatal() types.Event {
 	return &Event{
 		level:  slog.LevelError + 1,

--- a/loggers/zerolog/context.go
+++ b/loggers/zerolog/context.go
@@ -1,0 +1,103 @@
+package zerolog
+
+import (
+	"net"
+
+	"github.com/loopholelabs/logging/types"
+	"github.com/rs/zerolog"
+)
+
+var _ types.Context = (*Context)(nil)
+
+type Context struct {
+	l       *Logger
+	zeroCtx zerolog.Context
+}
+
+func (c *Context) Logger() types.SubLogger {
+	return &Logger{
+		logger: c.zeroCtx.Logger(),
+		source: c.l.source,
+		level:  c.l.level,
+	}
+}
+
+func (c *Context) Str(key string, val string) types.Context {
+	c.zeroCtx = c.zeroCtx.Str(key, val)
+	return c
+}
+
+func (c *Context) Bool(key string, val bool) types.Context {
+	c.zeroCtx = c.zeroCtx.Bool(key, val)
+	return c
+}
+
+func (c *Context) Int(key string, val int) types.Context {
+	c.zeroCtx = c.zeroCtx.Int(key, val)
+	return c
+}
+
+func (c *Context) Int8(key string, val int8) types.Context {
+	c.zeroCtx = c.zeroCtx.Int8(key, val)
+	return c
+}
+
+func (c *Context) Int16(key string, val int16) types.Context {
+	c.zeroCtx = c.zeroCtx.Int16(key, val)
+	return c
+}
+
+func (c *Context) Int32(key string, val int32) types.Context {
+	c.zeroCtx = c.zeroCtx.Int32(key, val)
+	return c
+}
+
+func (c *Context) Int64(key string, val int64) types.Context {
+	c.zeroCtx = c.zeroCtx.Int64(key, val)
+	return c
+}
+
+func (c *Context) Uint(key string, val uint) types.Context {
+	c.zeroCtx = c.zeroCtx.Uint(key, val)
+	return c
+}
+
+func (c *Context) Uint8(key string, val uint8) types.Context {
+	c.zeroCtx = c.zeroCtx.Uint8(key, val)
+	return c
+}
+
+func (c *Context) Uint16(key string, val uint16) types.Context {
+	c.zeroCtx = c.zeroCtx.Uint16(key, val)
+	return c
+}
+
+func (c *Context) Uint32(key string, val uint32) types.Context {
+	c.zeroCtx = c.zeroCtx.Uint32(key, val)
+	return c
+}
+
+func (c *Context) Uint64(key string, val uint64) types.Context {
+	c.zeroCtx = c.zeroCtx.Uint64(key, val)
+	return c
+}
+
+func (c *Context) Float32(key string, val float32) types.Context {
+	c.zeroCtx = c.zeroCtx.Float32(key, val)
+	return c
+}
+
+func (c *Context) Float64(key string, val float64) types.Context {
+	c.zeroCtx = c.zeroCtx.Float64(key, val)
+	return c
+}
+
+func (c *Context) IPAddr(key string, val net.IP) types.Context {
+	c.zeroCtx = c.zeroCtx.IPAddr(key, val)
+	return c
+}
+
+func (c *Context) MACAddr(key string, val net.HardwareAddr) types.Context {
+	c.zeroCtx = c.zeroCtx.MACAddr(key, val)
+	return c
+}

--- a/loggers/zerolog/zerolog.go
+++ b/loggers/zerolog/zerolog.go
@@ -65,6 +65,13 @@ func (z *Logger) SubLogger(source string) types.SubLogger {
 	}
 }
 
+func (z *Logger) With() types.Context {
+	return &Context{
+		l:       z,
+		zeroCtx: z.logger.With(),
+	}
+}
+
 func (z *Logger) Fatal() types.Event {
 	return (*Event)(z.logger.Fatal().Timestamp().Str(types.SourceKey, z.source))
 }

--- a/types/types.go
+++ b/types/types.go
@@ -29,6 +29,7 @@ type Logger interface {
 type SubLogger interface {
 	Level() Level
 	SubLogger(source string) SubLogger
+	With() Context
 
 	Fatal() Event
 	Error() Event
@@ -64,4 +65,29 @@ type Event interface {
 
 	Msg(msg string)
 	Msgf(format string, args ...interface{})
+}
+
+type Context interface {
+	Logger() SubLogger
+
+	Str(key string, val string) Context
+	Bool(key string, val bool) Context
+
+	Int(key string, val int) Context
+	Int8(key string, val int8) Context
+	Int16(key string, val int16) Context
+	Int32(key string, val int32) Context
+	Int64(key string, val int64) Context
+
+	Uint(key string, val uint) Context
+	Uint8(key string, val uint8) Context
+	Uint16(key string, val uint16) Context
+	Uint32(key string, val uint32) Context
+	Uint64(key string, val uint64) Context
+
+	Float32(key string, val float32) Context
+	Float64(key string, val float64) Context
+
+	IPAddr(key string, ipAddr net.IP) Context
+	MACAddr(key string, macAddr net.HardwareAddr) Context
 }


### PR DESCRIPTION
Add `With()` method to loggers to create a sublogger with a set of persistent labels that can be used to generate consistent log messages for a given resource.