### PR TITLE
level: implement pflag.Value interface

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+var (
+	ErrInvalidLogLevel = errors.New("invalid log level")
+)
+
 type Level int
 
 const (
@@ -57,7 +61,7 @@ func (l *Level) Set(v string) error {
 	case "trace":
 		*l = TraceLevel
 	default:
-		return errors.New("invalid log level")
+		return ErrInvalidLogLevel
 	}
 
 	return nil

--- a/types/types.go
+++ b/types/types.go
@@ -2,7 +2,11 @@
 
 package types
 
-import "net"
+import (
+	"errors"
+	"net"
+	"strings"
+)
 
 type Level int
 
@@ -14,6 +18,50 @@ const (
 	DebugLevel
 	TraceLevel
 )
+
+func (l Level) String() string {
+	switch l {
+	case FatalLevel:
+		return "FATAL"
+	case ErrorLevel:
+		return "ERROR"
+	case WarnLevel:
+		return "WARN"
+	case InfoLevel:
+		return "INFO"
+	case DebugLevel:
+		return "DEBUG"
+	case TraceLevel:
+		return "TRACE"
+	default:
+		return "invalid"
+	}
+}
+
+func (l Level) Type() string {
+	return "log level"
+}
+
+func (l *Level) Set(v string) error {
+	switch strings.ToLower(v) {
+	case "fatal":
+		*l = FatalLevel
+	case "error":
+		*l = ErrorLevel
+	case "warn":
+		*l = WarnLevel
+	case "info":
+		*l = InfoLevel
+	case "debug":
+		*l = DebugLevel
+	case "trace":
+		*l = TraceLevel
+	default:
+		return errors.New("invalid log level")
+	}
+
+	return nil
+}
 
 const (
 	TimestampKey = "time"


### PR DESCRIPTION
Implement `pflag.Value` interface for `Level` so it can be used as a CLI flag.